### PR TITLE
Clean up dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.slf4j" % "slf4j-simple" % "1.7.25" % "test",
-  "org.specs2" %% "specs2-core" % "3.8.9",
-  "org.specs2" %% "specs2-mock" % "3.8.9"
+  "org.specs2" %% "specs2-core" % "3.8.9" % "test",
+  "org.specs2" %% "specs2-mock" % "3.8.9" % "test"
 )
 
 useGpg := true

--- a/src/test/scala/com/hunorkovacs/koauth/service/provider/persistence/PersistenceSpec.scala
+++ b/src/test/scala/com/hunorkovacs/koauth/service/provider/persistence/PersistenceSpec.scala
@@ -1,9 +1,9 @@
 package com.hunorkovacs.koauth.service.provider.persistence
 
 import com.hunorkovacs.koauth.service.DefaultTokenGenerator._
-import org.specs2.mutable.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 import scala.concurrent.Await._


### PR DESCRIPTION
Move `PersistenceSpec.scala` to test tree, add test qualifier on dependencies. Specs uses scalaz, which is particularly sensitive to version mismatches, so this fix is important for projects that use Scalaz.